### PR TITLE
APILogger: pprintで出力するmodeを追加

### DIFF
--- a/slackbot/action/_api_logger.py
+++ b/slackbot/action/_api_logger.py
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
 
 
+import enum as _enum
 import logging as _logging
+import pprint as _pprint
 from .. import Action, Option
+
+
+class Mode(_enum.Enum):
+    raw = _enum.auto()
+    pprint = _enum.auto()
 
 
 class APILogger(Action):
@@ -28,11 +35,22 @@ class APILogger(Action):
             if (not self.config.output_user_typing and
                     api['type'] == 'user_typing'):
                 continue
-            self._logger.info(api)
+            # raw
+            if self.config.mode is Mode.raw:
+                self._logger.info(api)
+            # pprint
+            elif self.config.mode is Mode.pprint:
+                self._logger.info(
+                        '\n{0}'.format(_pprint.pformat(api, indent=2)))
 
     @staticmethod
     def option_list():
         return (
+            Option('mode',
+                   action= lambda mode: getattr(Mode, mode),
+                   default='raw',
+                   choices=[mode.name for mode in Mode],
+                   help='output format'),
             Option('output_presence_change',
                    type=bool,
                    default=True,


### PR DESCRIPTION
slackbot.action.APILogger
    Modeを作成した.
        raw: 従来通り1行で出力する
        pprint: pprintを用いて複数行で出力する
    Modeを設定するOptionを追加した.