### PR TITLE
Download

### DIFF
--- a/slackbot/action/_download.py
+++ b/slackbot/action/_download.py
@@ -157,7 +157,8 @@ class Download(Action):
                     process.start(
                                 chunk_size=self.config.chunk_size,
                                 report_interval=self.config.report_interval,
-                                speedmeter_size=self.config.speedmeter_size)
+                                speedmeter_size=self.config.speedmeter_size,
+                                permission=0o644)
                     self._process_list.append(process)
         # update process list
         finished_process_list = [

--- a/slackbot/action/_download.py
+++ b/slackbot/action/_download.py
@@ -158,7 +158,7 @@ class Download(Action):
                                 chunk_size=self.config.chunk_size,
                                 report_interval=self.config.report_interval,
                                 speedmeter_size=self.config.speedmeter_size,
-                                permission=0o644)
+                                permission=self.config.file_permission)
                     self._process_list.append(process)
         # update process list
         finished_process_list = [
@@ -169,6 +169,13 @@ class Download(Action):
 
     @staticmethod
     def option_list() -> Tuple[Option, ...]:
+        # parse permission (format 0oXXX)
+        def read_permission(value: str) -> Optional[int]:
+            match = re.match('0o(?P<permission>[0-7]{3})', value)
+            if match:
+                return int(match.group('permission'), base=8)
+            return None
+
         return (
             Option('channel',
                    action=lambda x: [x] if isinstance(x, str) else x,
@@ -202,4 +209,8 @@ class Download(Action):
             Option('least_size',
                    type=int,
                    help=('minimun file size'
-                         ' to be concidered successful download')))
+                         ' to be concidered successful download')),
+            Option('file_permission',
+                   action=read_permission,
+                   default='0o644',
+                   help='downloaded file permission (format: 0oXXX)'))

--- a/slackbot/action/_download_thread.py
+++ b/slackbot/action/_download_thread.py
@@ -217,7 +217,8 @@ class DownloadThread(threading.Thread):
                 url: str,
                 chunk_size: int = 1024,
                 report_interval: float = 5.0,
-                speedmeter_size: int = 100) -> None:
+                speedmeter_size: int = 100,
+                permission: Optional[int] = None) -> None:
         threading.Thread.__init__(self)
         self._observer = observer
         self._path = path
@@ -225,6 +226,7 @@ class DownloadThread(threading.Thread):
         self._chunk_size = chunk_size
         self._report_interval = report_interval
         self._speedmeter_size = speedmeter_size
+        self._permission = permission
 
     def run(self) -> None:
         with tempfile.NamedTemporaryFile(
@@ -302,6 +304,9 @@ class DownloadThread(threading.Thread):
                                     .format(self._path, index))
                     index += 1
             shutil.move(temp_file_path.as_posix(), save_path.as_posix())
+        # chmod
+        if self._permission is not None:
+            save_path.chmod(self._permission)
         # finish report
         progress = DownloadProgress(
                     file_size=file_size,

--- a/slackbot/action/_download_thread.py
+++ b/slackbot/action/_download_thread.py
@@ -227,7 +227,10 @@ class DownloadThread(threading.Thread):
         self._speedmeter_size = speedmeter_size
 
     def run(self) -> None:
-        with tempfile.NamedTemporaryFile(mode='wb', delete=False) as temp_file:
+        with tempfile.NamedTemporaryFile(
+                        mode='wb',
+                        delete=False,
+                        dir=self._path.parent.as_posix()) as temp_file:
             temp_file_path = pathlib.Path(temp_file.name)
             # initialize parameter
             file_size: Optional[int] = None


### PR DESCRIPTION
- temp file作成先をdefaultから変更
  - `/tmp`のsize制限を避けるため
- download後のfileに任意のpermissionを設定
  - 以前は0o600固定だった