### PR TITLE
loggerが2重出力される問題を解消

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -17,8 +17,9 @@ if __name__ == '__main__':
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler()
     handler.formatter = logging.Formatter(
-                fmt='%(name)s::%(levelname)s::%(message)s')
+                fmt='[%(levelname)s] %(name)s: %(message)s')
     logger.addHandler(handler)
+    logger.propagate = False
 
     bot = slackbot.create(
                 'Sample',


### PR DESCRIPTION
slackclient.SlackClient.rtm_connect()後にloggerが2重に出力されていた.
原因は, slackclientにてlogging.debug(...)が実行されたことで, handlerが追加されていたため.

Logger.propagateをFalseにし, root loggerのhandlerを回避することで対処した.