### PR TITLE
Option改修

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -8,8 +8,10 @@ import slackbot.action
 
 class DummyAction(slackbot.Action):
     @staticmethod
-    def option_list():
-        return (slackbot.Option('foo', help='bar'),)
+    def option_list(name: str) -> slackbot.OptionList:
+        return slackbot.OptionList(
+            name,
+            [slackbot.Option('foo', help='bar')])
 
 
 if __name__ == '__main__':

--- a/slackbot/__init__.py
+++ b/slackbot/__init__.py
@@ -2,4 +2,4 @@
 
 from ._action import Action, escape_text, unescape_text
 from ._core import create
-from ._config import Option, OptionError
+from ._config import Option, OptionError, OptionList

--- a/slackbot/_action.py
+++ b/slackbot/_action.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Optional, Dict, List, Optional, Tuple
 from ._client import Client
-from ._config import Option
+from ._config import OptionList
 from ._team import Team
 
 
@@ -43,8 +43,8 @@ class Action:
         return Team(key=self._key)
 
     @staticmethod
-    def option_list() -> Tuple[Option, ...]:
-        return tuple()
+    def option_list(name: str) -> OptionList:
+        return OptionList(name, [])
 
 
 def escape_text(string: str) -> str:

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -3,6 +3,7 @@
 import collections
 import sys
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
+import yaml
 
 
 class OptionError(Exception):
@@ -86,8 +87,11 @@ class Option:
     def sample_message(self) -> List[str]:
         result: List[str] = []
         sample = self.default
-        if isinstance(sample, (str, int, float, bool)):
-            result.append('{0}: {1}'.format(self.name, sample))
+        if sample is not None:
+            result.extend(
+                    yaml.dump({self.name: sample}, default_flow_style=False)
+                    .strip()
+                    .split('\n'))
         else:
             result.append('{0}:'.format(self.name))
         return result

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -22,6 +22,7 @@ class Option:
                  type: Optional[Type] = None,
                  choices: Optional[Iterable] = None,
                  required: bool = False,
+                 sample: Optional[Any] = None,
                  help: str = "") -> None:
         self.name = name
         if action is not None:
@@ -38,6 +39,7 @@ class Option:
         self.choices = choices
         assert isinstance(required, bool)
         self.required = required
+        self.sample = sample
         self.help = help
 
     def evaluate(self, data: Dict[str, Any]) -> Any:
@@ -79,7 +81,7 @@ class Option:
 
     def sample_message(self) -> List[str]:
         result: List[str] = []
-        sample = self.default
+        sample = self.sample if self.sample is not None else self.default
         if sample is not None:
             result.extend(
                     yaml.dump({self.name: sample}, default_flow_style=False)

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -81,6 +81,7 @@ class Option:
 
     def sample_message(self) -> List[str]:
         result: List[str] = []
+        result.append('# {0}'.format(self.help_message()))
         sample = self.sample if self.sample is not None else self.default
         if sample is not None:
             result.extend(
@@ -140,7 +141,6 @@ class ConfigParser:
         strline = []
         strline.append('{0}:'.format(self.name))
         for option in self.option_list:
-            strline.append('  # {0}'.format(option.help_message()))
             strline.extend('  {0}'.format(line)
                            for line in option.sample_message())
         return '\n'.join(strline)

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -169,8 +169,8 @@ class OptionList:
 
 
 class ConfigParser:
-    def __init__(self, name: str, option_list: Tuple[Option, ...]) -> None:
-        self._option_list = OptionList(name, option_list)
+    def __init__(self, option_list: OptionList) -> None:
+        self._option_list = option_list
 
     def parse(self, data: Optional[Dict[str, Any]]) -> Any:
         input_ = InputValue(False, data if data is not None else {})

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -161,6 +161,12 @@ class OptionList:
             line.extend(option.sample_message(indent + 2))
         return line
 
+    def append(self, x: Option) -> None:
+        self._list.append(x)
+
+    def extend(self, iterable: Iterable[Option]) -> None:
+        self._list.extend(iterable)
+
 
 class ConfigParser:
     def __init__(self, name: str, option_list: Tuple[Option, ...]) -> None:

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -133,5 +133,9 @@ class ConfigParser:
         strline.append('{0}:'.format(self.name))
         for option in self.option_list:
             strline.append('  # {0}'.format(option.help_message()))
-            strline.append('  {0}:'.format(option.name))
+            default = option.default
+            if isinstance(default, (str, int, float, bool)):
+                strline.append('  {0}: {1}'.format(option.name, default))
+            else:
+                strline.append('  {0}:'.format(option.name))
         return '\n'.join(strline)

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -132,7 +132,6 @@ class ConfigParser:
         strline = []
         strline.append('{0}:'.format(self.name))
         for option in self.option_list:
-            strline.append('  {0}: # {1}'.format(
-                        option.name,
-                        option.help_message()))
+            strline.append('  # {0}'.format(option.help_message()))
+            strline.append('  {0}:'.format(option.name))
         return '\n'.join(strline)

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -2,7 +2,7 @@
 
 import collections
 import sys
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Type
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 
 
 class OptionError(Exception):
@@ -83,6 +83,15 @@ class Option:
         ss.append('({0})'.format('required' if self.required else 'optional'))
         return ''.join(ss)
 
+    def sample_message(self) -> List[str]:
+        result: List[str] = []
+        sample = self.default
+        if isinstance(sample, (str, int, float, bool)):
+            result.append('{0}: {1}'.format(self.name, sample))
+        else:
+            result.append('{0}:'.format(self.name))
+        return result
+
 
 class ConfigParser:
     def __init__(self, name: str, option_list: Tuple[Option, ...]) -> None:
@@ -133,9 +142,6 @@ class ConfigParser:
         strline.append('{0}:'.format(self.name))
         for option in self.option_list:
             strline.append('  # {0}'.format(option.help_message()))
-            default = option.default
-            if isinstance(default, (str, int, float, bool)):
-                strline.append('  {0}: {1}'.format(option.name, default))
-            else:
-                strline.append('  {0}:'.format(option.name))
+            strline.extend('  {0}'.format(line)
+                           for line in option.sample_message())
         return '\n'.join(strline)

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -30,7 +30,7 @@ class Option:
                  choices: Optional[Iterable] = None,
                  required: bool = False,
                  sample: Optional[Any] = None,
-                 help: str = "") -> None:
+                 help: str = '') -> None:
         self.name = name
         if action is not None:
             assert callable(action)
@@ -105,9 +105,11 @@ class OptionList:
     def __init__(
             self,
             name: str,
-            options: Iterable[Union[Option, 'OptionList']]) -> None:
+            options: Iterable[Union[Option, 'OptionList']],
+            help: str = '') -> None:
         self.name = name
         self._list: List[Union[Option, 'OptionList']] = list(options)
+        self.help = help
 
     def evaluate(self, input_: InputValue):
         if input_.is_none:
@@ -152,6 +154,8 @@ class OptionList:
 
     def sample_message(self, indent: int = 0) -> List[str]:
         line = []
+        if self.help:
+            line.append('{0}# {1}'.format(' ' * indent, self.help))
         line.append('{0}{1}:'.format(' ' * indent, self.name))
         for option in self._list:
             line.extend(option.sample_message(indent + 2))

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -79,18 +79,19 @@ class Option:
         ss.append('({0})'.format('required' if self.required else 'optional'))
         return ''.join(ss)
 
-    def sample_message(self) -> List[str]:
-        result: List[str] = []
-        result.append('# {0}'.format(self.help_message()))
+    def sample_message(self, indent: int = 0) -> List[str]:
+        line: List[str] = []
+        line.append('{0}# {1}'.format(' ' * indent, self.help_message()))
         sample = self.sample if self.sample is not None else self.default
         if sample is not None:
-            result.extend(
-                    yaml.dump({self.name: sample}, default_flow_style=False)
-                    .strip()
-                    .split('\n'))
+            yaml_text = yaml.dump(
+                    {self.name: sample},
+                    default_flow_style=False)
+            line.extend('{0}{1}'.format(' ' * indent, line)
+                        for line in yaml_text.strip().split('\n'))
         else:
-            result.append('{0}:'.format(self.name))
-        return result
+            line.append('{0}{1}:'.format(' ' * indent, self.name))
+        return line
 
 
 class ConfigParser:
@@ -141,6 +142,5 @@ class ConfigParser:
         strline = []
         strline.append('{0}:'.format(self.name))
         for option in self.option_list:
-            strline.extend('  {0}'.format(line)
-                           for line in option.sample_message())
+            strline.extend(option.sample_message(indent=2))
         return '\n'.join(strline)

--- a/slackbot/_config.py
+++ b/slackbot/_config.py
@@ -176,5 +176,6 @@ class ConfigParser:
         input = InputValue(False, data if data is not None else {})
         return self._option_list.evaluate(input)
 
-    def help_message(self) -> str:
-        return '\n'.join(self._option_list.sample_message(indent=0))
+    def sample_message(self) -> str:
+        return ''.join('{0}\n'.format(line)
+                       for line in self._option_list.sample_message(indent=0))

--- a/slackbot/_core.py
+++ b/slackbot/_core.py
@@ -131,9 +131,8 @@ def create(
     # show example of configuration file
     if option.show_config:
         logger.info('output example of configuration file')
-        sys.stdout.write('{0}\n'.format(
-                    '\n'.join(parser.help_message()
-                              for parser in config_parser_list.values())))
+        for parser in config_parser_list.values():
+            sys.stdout.write(parser.sample_message())
         sys.exit(0)
     # load configuration file
     if option.config is None:

--- a/slackbot/_core.py
+++ b/slackbot/_core.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 import yaml
 from ._action import Action
 from ._client import Client
-from ._config import ConfigParser, Option
+from ._config import ConfigParser, Option, OptionList
 from ._team import Team
 
 
@@ -70,16 +70,17 @@ class Core(Action):
         self._team.update(api_list)
 
     @staticmethod
-    def option_list() -> Tuple[Option, ...]:
-        return (
-            Option('token_file',
-                   required=True,
-                   help='path to the file '
-                        'that Slack Authentification token is written'),
-            Option('interval',
-                   default=1.0,
-                   type=float,
-                   help='interval(seconds) to read real time messaging API'))
+    def option_list(name: str) -> OptionList:
+        return OptionList(
+            name,
+            [Option('token_file',
+                    required=True,
+                    help='path to the file '
+                         'that Slack Authentification token is written'),
+             Option('interval',
+                    default=1.0,
+                    type=float,
+                    help='interval(seconds) to read real time messaging API')])
 
 
 def create(
@@ -123,9 +124,9 @@ def create(
     logger.debug('command line option: {0}'.format(option))
     # config parser
     config_parser_list: Dict[str, ConfigParser] = collections.OrderedDict()
-    config_parser_list['Core'] = ConfigParser('Core', Core.option_list())
+    config_parser_list['Core'] = ConfigParser(Core.option_list('Core'))
     config_parser_list.update(
-                (key, ConfigParser(key, action_dict[key].option_list()))
+                (key, ConfigParser(action_dict[key].option_list(key)))
                 for key in sorted(action_dict.keys()))
     # show example of configuration file
     if option.show_config:

--- a/slackbot/action/_api_logger.py
+++ b/slackbot/action/_api_logger.py
@@ -4,7 +4,7 @@ import enum
 import logging
 import pprint
 from typing import Any, Dict, List, Optional, Tuple
-from .. import Action, Option
+from .. import Action, Option, OptionList
 
 
 class Mode(enum.Enum):
@@ -46,22 +46,23 @@ class APILogger(Action):
                         '\n{0}'.format(pprint.pformat(api, indent=2)))
 
     @staticmethod
-    def option_list() -> Tuple[Option, ...]:
-        return (
-            Option('mode',
-                   action=lambda mode: getattr(Mode, mode),
-                   default='raw',
-                   choices=[mode.name for mode in Mode],
-                   help='output format'),
-            Option('ignore_reconnect_url',
-                   type=bool,
-                   default=True,
-                   help='ignore "reconnect_url" api'),
-            Option('ignore_presence_change',
-                   type=bool,
-                   default=True,
-                   help='ignore "presence_change" api'),
-            Option('ignore_user_typing',
-                   type=bool,
-                   default=True,
-                   help='ignore "user_typing" api'))
+    def option_list(name: str) -> OptionList:
+        return OptionList(
+            name,
+            [Option('mode',
+                    action=lambda mode: getattr(Mode, mode),
+                    default='raw',
+                    choices=[mode.name for mode in Mode],
+                    help='output format'),
+             Option('ignore_reconnect_url',
+                    type=bool,
+                    default=True,
+                    help='ignore "reconnect_url" api'),
+             Option('ignore_presence_change',
+                    type=bool,
+                    default=True,
+                    help='ignore "presence_change" api'),
+             Option('ignore_user_typing',
+                    type=bool,
+                    default=True,
+                    help='ignore "user_typing" api')])

--- a/slackbot/action/_download.py
+++ b/slackbot/action/_download.py
@@ -6,7 +6,7 @@ import pathlib
 import re
 from typing import Any, Dict, List, Optional, Tuple
 import requests
-from .. import Action, Option
+from .. import Action, Option, OptionList
 from .._client import Client
 from .._team import Channel
 from ._download_thread import DownloadObserver, DownloadProgress
@@ -171,7 +171,7 @@ class Download(Action):
             self._process_list.remove(finished_process)
 
     @staticmethod
-    def option_list() -> Tuple[Option, ...]:
+    def option_list(name: str) -> OptionList:
         # parse permission (format 0oXXX)
         def read_permission(value: str) -> Optional[int]:
             match = re.match('0o(?P<permission>[0-7]{3})', value)
@@ -179,44 +179,45 @@ class Download(Action):
                 return int(match.group('permission'), base=8)
             return None
 
-        return (
-            Option('channel',
-                   action=lambda x: (
-                           [] if x is None
-                           else [x] if isinstance(x, str)
-                           else x),
-                   default=None,
-                   help='target channel name (list or string)'),
-            Option('pattern',
-                   action=re.compile,
-                   default=r'download\s+"(?P<name>.+)"\s+'
-                           r'<(?P<url>https?://[\w/:%#\$&\?\(\)~\.=\+\-]+)'
-                           r'(|\|[^>]+)>',
-                   help=('regular expresion for working'
-                         ' which have simbolic groups named "name" & "url"')),
-            Option('destination_directory',
-                   action=lambda x: pathlib.Path().joinpath(x),
-                   default='./download',
-                   help='directory where files are saved'),
-            Option('chunk_size',
-                   default=1024,
-                   type=int,
-                   help='data chank size (byte) for streaming download'),
-            Option('report_interval',
-                   default=60.0,
-                   type=float,
-                   help=('interval in seconds'
-                         ' between download progress reports')),
-            Option('speedmeter_size',
-                   default=100,
-                   type=int,
-                   help=('number of data chunks'
-                         ' for download speed measurement')),
-            Option('least_size',
-                   action=lambda x: int(x) if x is not None else None,
-                   help='minimun file size'
-                        ' to be concidered successful download'),
-            Option('file_permission',
-                   action=read_permission,
-                   default='0o644',
-                   help='downloaded file permission (format: 0oXXX)'))
+        return OptionList(
+            name,
+            [Option('channel',
+                    action=lambda x: (
+                            [] if x is None
+                            else [x] if isinstance(x, str)
+                            else x),
+                    default=None,
+                    help='target channel name (list or string)'),
+             Option('pattern',
+                    action=re.compile,
+                    default=r'download\s+"(?P<name>.+)"\s+'
+                            r'<(?P<url>https?://[\w/:%#\$&\?\(\)~\.=\+\-]+)'
+                            r'(|\|[^>]+)>',
+                    help=('regular expresion for working'
+                          ' which have simbolic groups named "name" & "url"')),
+             Option('destination_directory',
+                    action=lambda x: pathlib.Path().joinpath(x),
+                    default='./download',
+                    help='directory where files are saved'),
+             Option('chunk_size',
+                    default=1024,
+                    type=int,
+                    help='data chank size (byte) for streaming download'),
+             Option('report_interval',
+                    default=60.0,
+                    type=float,
+                    help=('interval in seconds'
+                          ' between download progress reports')),
+             Option('speedmeter_size',
+                    default=100,
+                    type=int,
+                    help=('number of data chunks'
+                          ' for download speed measurement')),
+             Option('least_size',
+                    action=lambda x: int(x) if x is not None else None,
+                    help='minimun file size'
+                         ' to be concidered successful download'),
+             Option('file_permission',
+                    action=read_permission,
+                    default='0o644',
+                    help='downloaded file permission (format: 0oXXX)')])

--- a/slackbot/action/_download.py
+++ b/slackbot/action/_download.py
@@ -181,8 +181,11 @@ class Download(Action):
 
         return (
             Option('channel',
-                   action=lambda x: [x] if isinstance(x, str) else x,
-                   default=[],
+                   action=lambda x: (
+                           [] if x is None
+                           else [x] if isinstance(x, str)
+                           else x),
+                   default=None,
                    help='target channel name (list or string)'),
             Option('pattern',
                    action=re.compile,
@@ -210,9 +213,9 @@ class Download(Action):
                    help=('number of data chunks'
                          ' for download speed measurement')),
             Option('least_size',
-                   type=int,
-                   help=('minimun file size'
-                         ' to be concidered successful download')),
+                   action=lambda x: int(x) if x is not None else None,
+                   help='minimun file size'
+                        ' to be concidered successful download'),
             Option('file_permission',
                    action=read_permission,
                    default='0o644',

--- a/slackbot/action/_response.py
+++ b/slackbot/action/_response.py
@@ -199,4 +199,4 @@ def _is_url(value: str) -> bool:
 
 
 def _is_emoji(value: str) -> bool:
-    return bool( re.match(':[^:]+:', value))
+    return bool(re.match(':[^:]+:', value))

--- a/slackbot/action/_response.py
+++ b/slackbot/action/_response.py
@@ -6,7 +6,7 @@ import random
 import re
 from collections import OrderedDict
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
-from .. import Action, Option, OptionError, unescape_text
+from .. import Action, Option, OptionError, OptionList, unescape_text
 from .._team import Channel, User
 
 
@@ -73,7 +73,7 @@ class Response(Action):
                         api['text'])
 
     @staticmethod
-    def option_list() -> Tuple[Option, ...]:
+    def option_list(name: str) -> OptionList:
         # translate to Trigger
         to_trigger: Dict[str, Trigger] = OrderedDict()
         to_trigger['non-reply'] = Trigger.NON_REPLY
@@ -119,28 +119,29 @@ class Response(Action):
                 raise OptionError(message)
             return result
 
-        return (
-            Option('channel',
-                   action=lambda x: (
-                           [] if x is None
-                           else [x] if isinstance(x, str)
-                           else x),
-                   default=None,
-                   help='target channel name (list or string)'),
-            Option('trigger',
-                   default='non-reply',
-                   action=lambda x: to_trigger.get(x),
-                   choices=to_trigger.keys(),
-                   help='response trigger'),
-            Option('pattern',
-                   sample=[{'call': ['ping'], 'response': ['pong']}],
-                   action=parse_pattern_list,
-                   help='response pattern'),
-            Option('username',
-                   help='username'),
-            Option('icon',
-                   action=_check_icon,
-                   help='user icon (:emoji: or http://url/to/icon)'))
+        return OptionList(
+            name,
+            [Option('channel',
+                    action=lambda x: (
+                            [] if x is None
+                            else [x] if isinstance(x, str)
+                            else x),
+                    default=None,
+                    help='target channel name (list or string)'),
+             Option('trigger',
+                    default='non-reply',
+                    action=lambda x: to_trigger.get(x),
+                    choices=to_trigger.keys(),
+                    help='response trigger'),
+             Option('pattern',
+                    sample=[{'call': ['ping'], 'response': ['pong']}],
+                    action=parse_pattern_list,
+                    help='response pattern'),
+             Option('username',
+                    help='username'),
+             Option('icon',
+                    action=_check_icon,
+                    help='user icon (:emoji: or http://url/to/icon)')])
 
 
 def _response(

--- a/slackbot/action/_response.py
+++ b/slackbot/action/_response.py
@@ -112,7 +112,7 @@ class Response(Action):
             elif hasattr(data, '__iter__') and not isinstance(data, str):
                 for element in data:
                     result.append(parse_pattern(element))
-            else:
+            elif data is not None:
                 message = (
                     'could not convert to Pattern\'s list: \'{0}\''
                     .format(data))
@@ -133,7 +133,7 @@ class Response(Action):
                    choices=to_trigger.keys(),
                    help='response trigger'),
             Option('pattern',
-                   default=[{'call': ['ping'], 'response': ['pong']}],
+                   sample=[{'call': ['ping'], 'response': ['pong']}],
                    action=parse_pattern_list,
                    help='response pattern'),
             Option('username',

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -82,48 +82,68 @@ class OptionTest(unittest.TestCase):
         input = make_none_input()
         self.assertEqual(option.evaluate(input), '0xff')
 
+    def test_sample(self):
+        option = slackbot.Option('foo', sample='bar')
+        input = make_none_input()
+        self.assertEqual(option.evaluate(input), None)
 
-class OptionHelpTest(unittest.TestCase):
+
+class OptionSampleTest(unittest.TestCase):
     def test_plain(self):
         option = slackbot.Option('foo')
         self.assertEqual(
-                option.help_message(),
-                '(optional)')
+                option.sample_message(),
+                ['# (optional)',
+                 'foo:'])
+
+    def test_indent(self):
+        option = slackbot.Option('foo')
+        self.assertEqual(
+                option.sample_message(indent=2),
+                ['  # (optional)',
+                 '  foo:'])
 
     def test_required(self):
         option = slackbot.Option('foo', help='Foo', required=True)
         self.assertEqual(
-                option.help_message(),
-                'Foo (required)')
+                option.sample_message(),
+                ['# Foo (required)',
+                 'foo:'])
 
     def test_default(self):
         option = slackbot.Option('foo', help='Foo', default='bar')
         self.assertEqual(
-                option.help_message(),
-                'Foo (default: bar)(optional)')
+                option.sample_message(),
+                ['# Foo (default: bar)(optional)',
+                 'foo: bar'])
 
     def test_default_hidden(self):
         option = slackbot.Option('foo', help='Foo', default=b'')
         self.assertEqual(
-                option.help_message(),
-                'Foo (optional)')
+                option.sample_message(),
+                ['# Foo (optional)',
+                 'foo: !!binary ""'])
 
     def test_choices(self):
         option = slackbot.Option('foo', help='Foo', choices=(0, 1))
         self.assertEqual(
-                option.help_message(),
-                'Foo {0, 1}(optional)')
+                option.sample_message(),
+                ['# Foo {0, 1}(optional)',
+                 'foo:'])
 
-    def test_all(self):
-        option = slackbot.Option(
-                'foo',
-                default='foo',
-                choices=('foo', 'bar', 'baz'),
-                required=True,
-                help='Foo')
+    def test_sample(self):
+        option = slackbot.Option('foo', sample='FOO')
         self.assertEqual(
-                option.help_message(),
-                'Foo {foo, bar, baz}(default: foo)(required)')
+                option.sample_message(),
+                ['# (optional)',
+                 'foo: FOO'])
+
+    def test_sample_and_default(self):
+        option = slackbot.Option('foo', default='foo', sample='FOO')
+        self.assertEqual(
+                option.sample_message(),
+                ['# (default: foo)(optional)',
+                 'foo: FOO'])
 
 
 class ConfigParserTest(unittest.TestCase):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -9,167 +9,165 @@ import slackbot
 class OptionTest(unittest.TestCase):
     def test_plain(self):
         option = slackbot.Option('foo')
-        data = {'foo': 'bar'}
-        self.assertEqual(option.evaluate(data), 'bar')
+        input = make_input('bar')
+        self.assertEqual(option.evaluate(input), 'bar')
 
     def test_default(self):
         option = slackbot.Option('foo', default='0')
-        data = {}
-        self.assertEqual(option.evaluate(data), '0')
+        input = make_none_input()
+        self.assertEqual(option.evaluate(input), '0')
 
     def test_type(self):
         option = slackbot.Option('foo', type=int)
-        data = {'foo': '1'}
-        self.assertEqual(option.evaluate(data), 1)
+        input = make_input('1')
+        self.assertEqual(option.evaluate(input), 1)
 
     def test_type_with_default(self):
         option = slackbot.Option('foo', default='0', type=int)
-        data = {}
-        self.assertEqual(option.evaluate(data), 0)
+        input = make_none_input()
+        self.assertEqual(option.evaluate(input), 0)
 
     def test_type_without_default(self):
         option = slackbot.Option('foo', type=int)
-        data = {}
-        self.assertEqual(option.evaluate(data), None)
+        input = make_none_input()
+        with self.assertRaises(Exception):
+            self.assertEqual(option.evaluate(input), None)
 
     def test_required(self):
         option = slackbot.Option('foo', required=True)
-        data = {}
+        input = make_none_input()
         with self.assertRaises(slackbot.OptionError):
-            option.evaluate(data)
+            option.evaluate(input)
 
     def test_choices(self):
         option = slackbot.Option('foo', choices=('foo', 'bar',))
-        data = {'foo': 'bar'}
-        self.assertEqual(option.evaluate(data), 'bar')
+        input = make_input('bar')
+        self.assertEqual(option.evaluate(input), 'bar')
 
     def test_choices_failed(self):
         option = slackbot.Option('foo', choices=('foo', 'bar',))
-        data = {'foo': 'baz'}
+        input = make_input('baz')
         with self.assertRaises(slackbot.OptionError):
-            option.evaluate(data)
+            option.evaluate(input)
 
     def test_choices_with_type(self):
         option = slackbot.Option('foo', type=int, choices=(1, 2))
-        data = {'foo': '1'}
-        self.assertEqual(option.evaluate(data), 1)
-
-    def test_choices_with_type_failed(self):
-        option = slackbot.Option('foo', type=int, choices=(1, 2))
-        data = {'foo': '0'}
+        input = make_input('1')
         with self.assertRaises(slackbot.OptionError):
-            option.evaluate(data)
+            option.evaluate(input)
 
     def test_action(self):
         option = slackbot.Option('foo', action=str.upper)
-        data = {'foo': 'bar'}
-        self.assertEqual(option.evaluate(data), 'BAR')
+        input = make_input('bar')
+        self.assertEqual(option.evaluate(input), 'BAR')
 
     def test_action_with_type(self):
         option = slackbot.Option('foo', action=hex, type=int)
-        data = {'foo': '0'}
-        self.assertEqual(option.evaluate(data), '0x0')
+        input = make_input('0')
+        self.assertEqual(option.evaluate(input), '0x0')
 
     def test_action_with_default(self):
         option = slackbot.Option('foo', action=str.upper, default='bar')
-        data = {}
-        self.assertEqual(option.evaluate(data), 'BAR')
+        input = make_none_input()
+        self.assertEqual(option.evaluate(input), 'BAR')
 
     def test_action_without_default(self):
         option = slackbot.Option('foo', action=str.upper)
-        data = {}
-        self.assertEqual(option.evaluate(data), None)
+        input = make_none_input()
+        with self.assertRaises(Exception):
+            self.assertEqual(option.evaluate(input), None)
 
     def test_action_and_type_with_default(self):
         option = slackbot.Option('foo', action=hex, default='255', type=int)
-        data = {}
-        self.assertEqual(option.evaluate(data), '0xff')
+        input = make_none_input()
+        self.assertEqual(option.evaluate(input), '0xff')
 
 
 class OptionHelpTest(unittest.TestCase):
     def test_plain(self):
         option = slackbot.Option('foo')
         self.assertEqual(
-                    option.help_message(),
-                    '(optional)')
+                option.help_message(),
+                '(optional)')
 
     def test_required(self):
         option = slackbot.Option('foo', help='Foo', required=True)
         self.assertEqual(
-                    option.help_message(),
-                    'Foo (required)')
+                option.help_message(),
+                'Foo (required)')
 
     def test_default(self):
         option = slackbot.Option('foo', help='Foo', default='bar')
         self.assertEqual(
-                    option.help_message(),
-                    'Foo (default: bar)(optional)')
+                option.help_message(),
+                'Foo (default: bar)(optional)')
 
     def test_default_hidden(self):
         option = slackbot.Option('foo', help='Foo', default=b'')
         self.assertEqual(
-                    option.help_message(),
-                    'Foo (optional)')
+                option.help_message(),
+                'Foo (optional)')
 
     def test_choices(self):
         option = slackbot.Option('foo', help='Foo', choices=(0, 1))
         self.assertEqual(
-                    option.help_message(),
-                    'Foo {0, 1}(optional)')
+                option.help_message(),
+                'Foo {0, 1}(optional)')
 
     def test_all(self):
         option = slackbot.Option(
-                    'foo',
-                    default='foo',
-                    choices=('foo', 'bar', 'baz'),
-                    required=True,
-                    help='Foo')
+                'foo',
+                default='foo',
+                choices=('foo', 'bar', 'baz'),
+                required=True,
+                help='Foo')
         self.assertEqual(
-                    option.help_message(),
-                    'Foo {foo, bar, baz}(default: foo)(required)')
+                option.help_message(),
+                'Foo {foo, bar, baz}(default: foo)(required)')
 
 
 class ConfigParserTest(unittest.TestCase):
     def test_plain(self):
-        parser = slackbot._config.ConfigParser(
+        parser = slackbot._config.ConfigParser(slackbot.OptionList(
                 'Test',
-                (slackbot.Option('foo'), slackbot.Option('bar')))
+                [slackbot.Option('foo'),
+                 slackbot.Option('bar')]))
         data = {'foo': '0', 'bar': '1'}
         result = parser.parse(data)
         self.assertEqual(result.foo, '0')
         self.assertEqual(result.bar, '1')
 
     def test_dict(self):
-        parser = slackbot._config.ConfigParser(
+        parser = slackbot._config.ConfigParser(slackbot.OptionList(
                 'Test',
-                (slackbot.Option('foo'), ))
+                [slackbot.Option('foo')]))
         data = {'foo': {'bar': '0', 'baz': '1'}}
         result = parser.parse(data)
         self.assertEqual(result.foo.bar, '0')
         self.assertEqual(result.foo.baz, '1')
 
     def test_list(self):
-        parser = slackbot._config.ConfigParser(
+        parser = slackbot._config.ConfigParser(slackbot.OptionList(
                 'Test',
-                (slackbot.Option('foo'), ))
+                [slackbot.Option('foo')]))
         data = {'foo': ['bar', 'baz']}
         result = parser.parse(data)
         self.assertEqual(result.foo[0], 'bar')
         self.assertEqual(result.foo[1], 'baz')
 
     def test_dict_in_list(self):
-        parser = slackbot._config.ConfigParser(
+        parser = slackbot._config.ConfigParser(slackbot.OptionList(
                 'Test',
-                (slackbot.Option('foo'), ))
+                [slackbot.Option('foo')]))
         data = {'foo': [{'bar': '0'}, {'baz': '1'}]}
         result = parser.parse(data)
         self.assertEqual(result.foo[0].bar, '0')
         self.assertEqual(result.foo[1].baz, '1')
 
     def test_list_in_dict(self):
-        parser = slackbot._config.ConfigParser(
+        parser = slackbot._config.ConfigParser(slackbot.OptionList(
                 'Test',
-                (slackbot.Option('foo'), ))
+                [slackbot.Option('foo')]))
         data = {'foo': {'bar': ['0', '1']}}
         result = parser.parse(data)
         self.assertEqual(result.foo.bar[0], '0')
@@ -187,27 +185,27 @@ class ConfigParserExitTest(unittest.TestCase):
         self._stderr = None
 
     def test_unrecognized_argumets(self):
-        parser = slackbot._config.ConfigParser(
+        parser = slackbot._config.ConfigParser(slackbot.OptionList(
                 'Test',
-                (slackbot.Option('foo'), ))
+                [slackbot.Option('foo')]))
         data = {'foo': '0', 'bar': '1'}
         with self.assertRaises(SystemExit) as cm:
             retult = parser.parse(data)
         self.assertEqual(cm.exception.code, 2)
 
     def test_required_failed(self):
-        parser = slackbot._config.ConfigParser(
+        parser = slackbot._config.ConfigParser(slackbot.OptionList(
                 'Test',
-                (slackbot.Option('foo', required=True), ))
+                [slackbot.Option('foo', required=True)]))
         data = {}
         with self.assertRaises(SystemExit) as cm:
             retult = parser.parse(data)
         self.assertEqual(cm.exception.code, 2)
 
     def test_choices_failed(self):
-        parser = slackbot._config.ConfigParser(
+        parser = slackbot._config.ConfigParser(slackbot.OptionList(
                 'Test',
-                (slackbot.Option('foo', choices=('bar', 'baz')), ))
+                [slackbot.Option('foo', choices=('bar', 'baz'))]))
         data = {'foo': 'foo'}
         with self.assertRaises(SystemExit) as cm:
             retult = parser.parse(data)
@@ -216,15 +214,27 @@ class ConfigParserExitTest(unittest.TestCase):
 
 class ConfigParserHelpTest(unittest.TestCase):
     def test_plane(self):
-        parser = slackbot._config.ConfigParser(
+        parser = slackbot._config.ConfigParser(slackbot.OptionList(
                 'Test',
-                (slackbot.Option('foo'),
-                 slackbot.Option('bar')))
+                [slackbot.Option('foo'),
+                 slackbot.Option('bar')],
+                help='test'))
         self.assertEqual(
-                parser.help_message(),
-                "Test:\n"
-                "  foo: # (optional)\n"
-                "  bar: # (optional)")
+                parser.sample_message(),
+                '# test\n'
+                'Test:\n'
+                '  # (optional)\n'
+                '  foo:\n'
+                '  # (optional)\n'
+                '  bar:\n')
+
+
+def make_input(value):
+    return slackbot._config.InputValue(is_none=False, value=value)
+
+
+def make_none_input():
+    return slackbot._config.InputValue(is_none=True, value=None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- optionの階層化のためOptionList classを作成
  - 各Action classのoption_list()がOptionListを出力
- optionのhelp出力を変更
  - commentと'key: value'を別の行に出力
  - sample引数を作成
  - default値を入力済みの状態で生成
- optionの評価方法を統一