### PR TITLE
不完全なdownloadを検知

### DIFF
--- a/slackbot/action/_download_thread.py
+++ b/slackbot/action/_download_thread.py
@@ -393,7 +393,7 @@ class DownloadThread(threading.Thread, Generic[ReportInfo]):
             reporter.finish(
                     saved_path=save_path,
                     progress=progress.report())
-        except (DownloadException, requests.RequestException) as error:
+        except Exception as error:
             reporter.error(error=error)
             # remove temp file
             if temp_file_path is not None:

--- a/slackbot/action/_download_thread.py
+++ b/slackbot/action/_download_thread.py
@@ -351,13 +351,11 @@ class DownloadThread(threading.Thread, Generic[ReportInfo]):
             # move file
             with _move_file_lock:
                 save_path = self._path
-                if save_path.exists():
-                    index = 0
-                    while save_path.exists():
-                        save_path = self._path.parent.joinpath(
-                                        '{0.stem}_{1}{0.suffix}'
-                                        .format(self._path, index))
-                        index += 1
+                i = 0
+                while save_path.exists():
+                    save_path = self._path.with_name(
+                            '{0.stem}_{1}{0.suffix}'.format(self._path, i))
+                    i += 1
                 shutil.move(temp_file_path.as_posix(), save_path.as_posix())
             # chmod
             if self._option.file_permission is not None:

--- a/slackbot/action/_download_thread.py
+++ b/slackbot/action/_download_thread.py
@@ -133,6 +133,10 @@ class Progress:
         self._latest_time = time.perf_counter()
         self._speedmeter.push(self._downloaded_size)
 
+    def is_completed(self) -> bool:
+        return (self._file_size is None
+                or self._file_size == self._downloaded_size)
+
     def report(self) -> ProgressReport:
         return ProgressReport(
                 file_size=self._file_size,

--- a/slackbot/action/_download_thread.py
+++ b/slackbot/action/_download_thread.py
@@ -335,9 +335,7 @@ class DownloadThread(threading.Thread, Generic[ReportInfo]):
                 # streaming download
                 response = requests.get(self._url, stream=True)
                 # status code check
-                if ((response.status_code // 100 == 4)
-                        or (response.status_code // 100 == 5)):
-                    raise DownloadException(response)
+                response.raise_for_status()
                 # start report
                 reporter.start(
                         temp_path=temp_file_path,


### PR DESCRIPTION
downloadが途中で中断された場合にerror扱いするようにした

変更点
- Progress.is_completed()を追加
- downloadが不完全なことを示す例外を作成
- ReporterからProgressを分離
  - ProgressTimer classを作成
- 例外補足の変更
  - try catchの範囲を広げた
  - 全ての例外をcatchする