### PR TITLE
Convarsations APIへ移行

### DIFF
--- a/slackbot/__init__.py
+++ b/slackbot/__init__.py
@@ -3,4 +3,4 @@
 from ._action import Action, escape_text, unescape_text
 from ._core import create
 from ._option import Option, OptionError, OptionList
-from ._team import Channel, ChannelList, Group, GroupList, Team, User, UserList
+from ._team import Channel, ChannelList, Team, User, UserList

--- a/slackbot/_team.py
+++ b/slackbot/_team.py
@@ -90,13 +90,6 @@ class Channel:
                 last_set=self._data['purpose']['last_set'])
 
     @property
-    def members(self) -> List[User]:
-        return list(filter(
-                None,
-                map(Team().user_list.id_search,
-                    self._data['members'])))
-
-    @property
     def is_archived(self) -> bool:
         return self._data['is_archived']
 

--- a/slackbot/_team.py
+++ b/slackbot/_team.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import enum
-from typing import Any, Dict, Iterable, Iterator, List, Optional
+from typing import Any, Dict, Iterable, Iterator, List, NamedTuple, Optional
 import slack
 
 
@@ -35,6 +35,12 @@ class ChannelType(enum.Enum):
     MPIM = enum.auto()
 
 
+class ChannelTopic(NamedTuple):
+    value: str
+    creator: str
+    last_set: int
+
+
 class Channel:
     def __init__(
             self,
@@ -64,6 +70,24 @@ class Channel:
             else ChannelType.IM if self._data.get('is_im', False)
             else ChannelType.MPIM if self._data.get('is_mpim', False)
             else ChannelType.UNKNOWN)
+
+    @property
+    def topic(self) -> Optional[ChannelTopic]:
+        if 'topic' not in self._data:
+            return None
+        return ChannelTopic(
+                value=self._data['topic']['value'],
+                creator=self._data['topic']['creator'],
+                last_set=self._data['topic']['last_set'])
+
+    @property
+    def purpose(self) -> Optional[ChannelTopic]:
+        if 'purpose' not in self._data:
+            return None
+        return ChannelTopic(
+                value=self._data['purpose']['value'],
+                creator=self._data['purpose']['creator'],
+                last_set=self._data['purpose']['last_set'])
 
     @property
     def members(self) -> List[User]:

--- a/slackbot/_team.py
+++ b/slackbot/_team.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import enum
 from typing import Any, Dict, Iterable, Iterator, List, Optional
 import slack
 
@@ -24,6 +25,14 @@ class User:
     @property
     def name(self) -> str:
         return self._data['name']
+
+
+class ChannelType(enum.Enum):
+    UNKNOWN = enum.auto()
+    CHANNEL = enum.auto()
+    GROUP = enum.auto()
+    IM = enum.auto()
+    MPIM = enum.auto()
 
 
 class Channel:

--- a/slackbot/_team.py
+++ b/slackbot/_team.py
@@ -57,6 +57,15 @@ class Channel:
         return self._data['name']
 
     @property
+    def type(self) -> ChannelType:
+        return (
+            ChannelType.CHANNEL if self._data.get('is_channel', False)
+            else ChannelType.GROUP if self._data.get('is_group', False)
+            else ChannelType.IM if self._data.get('is_im', False)
+            else ChannelType.MPIM if self._data.get('is_mpim', False)
+            else ChannelType.UNKNOWN)
+
+    @property
     def members(self) -> List[User]:
         return list(filter(
                 None,
@@ -66,6 +75,10 @@ class Channel:
     @property
     def is_archived(self) -> bool:
         return self._data['is_archived']
+
+    @property
+    def is_private(self) -> bool:
+        return self.type is not ChannelType.CHANNEL
 
 
 class Group:


### PR DESCRIPTION
[Deprecating early methods in favor of the Conversations API](https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api)
`channels.*`, `groups.*`, `im.*`, `npim.*`のAPIがdeprecatedとなったため, `conversations.*`のAPIに移行した.

channel, groupのAPI上の区別がなくなったので, Group, GroupList classをChannel, ChannelList classへ統合した.