### PR TITLE
ClearHistory Actionを作成

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -32,6 +32,7 @@ if __name__ == '__main__':
     bot = slackbot.create(
                 'Sample',
                 action_dict={'APILogger': slackbot.action.APILogger,
+                             'ClearHistory': slackbot.action.ClearHistory,
                              'Download': slackbot.action.Download,
                              'Dummy': DummyAction,
                              'Response': slackbot.action.Response},

--- a/slackbot/_action.py
+++ b/slackbot/_action.py
@@ -37,6 +37,9 @@ class Action(Generic[OptionType]):
     def update(self, client: slack.WebClient) -> Union[None, Coroutine[Any, Any, None]]:
         pass
 
+    def stop(self) -> None:
+        pass
+
     @property
     def name(self) -> str:
         return self._name

--- a/slackbot/_core.py
+++ b/slackbot/_core.py
@@ -94,6 +94,8 @@ class Core(Action[CoreOption]):
         self._is_running = False
         if self._rtm_client is not None:
             self._rtm_client.stop()
+        for action in self._action_dict.values():
+            action.stop()
 
     def register(self) -> None:
         self._update_team.register()

--- a/slackbot/action/__init__.py
+++ b/slackbot/action/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from ._api_logger import APILogger
+from ._clear_history import ClearHistory
 from ._download import Download
 from ._option import AvatarOption
 from ._response import Response

--- a/slackbot/action/_clear_history.py
+++ b/slackbot/action/_clear_history.py
@@ -124,6 +124,7 @@ class ClearHistory(Action[ClearHistoryOption]):
 
     async def _execute(self, client: slack.WebClient) -> None:
         try:
+            self._logger.info('begin execution')
             # target
             targets: List[_DeleteTarget] = []
             for channel in self.option.channels:
@@ -140,6 +141,7 @@ class ClearHistory(Action[ClearHistoryOption]):
                 response.validate()
                 await asyncio.sleep(self.option.api_interval)
                 self._can_continue()
+            self._logger.info('end execution')
         except _ExecutionStop:
             self._logger.info('execution is stopped')
             return
@@ -181,6 +183,15 @@ class ClearHistory(Action[ClearHistoryOption]):
                         _to_datetime(response['messages'][-1]['ts']),
                         len(result))
             self._can_continue()
+        if result:
+            self._logger.info(
+                    'channel "%s": %d target (%s - %s)',
+                    channel.name,
+                    len(result),
+                    _to_datetime(result[0]['ts']),
+                    _to_datetime(result[-1]['ts']))
+        else:
+            self._logger.info('channel "%s": no target', channel.name)
         return result
 
     def _can_continue(self) -> None:

--- a/slackbot/action/_clear_history.py
+++ b/slackbot/action/_clear_history.py
@@ -66,7 +66,7 @@ class ClearHistoryOption(NamedTuple):
                         help='clear execution interval of (seconds)'),
                  Option('api_interval',
                         type=float,
-                        default=1.0,
+                        default=5.0,
                         help='slack api execution interval (seconds)'),
                  Option('channels',
                         sample=[{'name': 'CHANNEL_NAME', 'period': 24}],

--- a/slackbot/action/_clear_history.py
+++ b/slackbot/action/_clear_history.py
@@ -11,8 +11,8 @@ from .. import Action, Option, OptionError, OptionList
 
 class ChannelOption:
     def __init__(self, name: str, period: Union[float, int]) -> None:
-        assert(isinstance(name, str))
-        assert(isinstance(period, (float, int)))
+        assert isinstance(name, str)
+        assert isinstance(period, (float, int))
         self._name = name
         self._period = datetime.timedelta(hours=period)
 

--- a/slackbot/action/_clear_history.py
+++ b/slackbot/action/_clear_history.py
@@ -124,9 +124,20 @@ class ClearHistory(Action[ClearHistoryOption]):
 
     async def _execute(self, client: slack.WebClient) -> None:
         try:
+            # target
             targets: List[_DeleteTarget] = []
             for channel in self.option.channels:
                 targets.extend(await self._target_messages(client, channel))
+            # delete
+            for target in targets:
+                self._logger.debug(
+                        'delete: channel "%s", %s',
+                        target['channel'],
+                        datetime.datetime.fromtimestamp(float(target['ts'])))
+                response = await client.chat_delete(**target)
+                response.validate()
+                await asyncio.sleep(self.option.api_interval)
+                self._can_continue()
         except _ExecutionStop:
             self._logger.info('execution is stopped')
             return

--- a/slackbot/action/_clear_history.py
+++ b/slackbot/action/_clear_history.py
@@ -1,18 +1,59 @@
 # -*- cpding: utf-8 -*-
 
+import datetime
 import logging
-from typing import NamedTuple, Optional
-from .. import Action, Option, OptionList
+from typing import Any, List, NamedTuple, Optional, Tuple, Union
+from .. import Action, Option, OptionError, OptionList
+
+
+class ChannelOption:
+    def __init__(self, name: str, period: Union[float, int]) -> None:
+        assert(isinstance(name, str))
+        assert(isinstance(period, (float, int)))
+        self._name = name
+        self._period = datetime.timedelta(hours=period)
+
+    def __repr__(self) -> str:
+        return "{0}.{1}(name={2}, period={3})".format(
+                self.__class__.__module__,
+                self.__class__.__name__,
+                repr(self._name),
+                repr(self._period))
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def period(self) -> datetime.timedelta:
+        return self._period
 
 
 class ClearHistoryOption(NamedTuple):
     sleep: float
     api_interval: float
+    channels: Tuple[ChannelOption, ...]
 
     @staticmethod
     def option_list(
             name: str,
             help: str = '') -> OptionList['ClearHistoryOption']:
+        def parse_channel(data: Any) -> Tuple[ChannelOption, ...]:
+            result: List[ChannelOption] = []
+            if not (isinstance(data, list)
+                    and all(map(lambda x: isinstance(x, dict), data))):
+                raise OptionError(
+                    'could not convert to ChannelOption\'s list: \'{0}\''
+                    .format(data))
+            for channel in data:
+                try:
+                    result.append(ChannelOption(**channel))
+                except (AssertionError, TypeError):
+                    raise OptionError(
+                            'could not convert to ChannelOption: \'{0}\''
+                            .format(channel))
+            return tuple(result)
+
         return OptionList(
                 ClearHistoryOption,
                 name,
@@ -23,7 +64,11 @@ class ClearHistoryOption(NamedTuple):
                  Option('api_interval',
                         type=float,
                         default=1.0,
-                        help='slack api execution interval (seconds)')],
+                        help='slack api execution interval (seconds)'),
+                 Option('channels',
+                        sample=[{'name': 'CHANNEL_NAME', 'period': 24}],
+                        action=parse_channel,
+                        help='target channels')],
                 help=help)
 
 

--- a/slackbot/action/_clear_history.py
+++ b/slackbot/action/_clear_history.py
@@ -1,0 +1,43 @@
+# -*- cpding: utf-8 -*-
+
+import logging
+from typing import NamedTuple, Optional
+from .. import Action, Option, OptionList
+
+
+class ClearHistoryOption(NamedTuple):
+    sleep: float
+    api_interval: float
+
+    @staticmethod
+    def option_list(
+            name: str,
+            help: str = '') -> OptionList['ClearHistoryOption']:
+        return OptionList(
+                ClearHistoryOption,
+                name,
+                [Option('sleep',
+                        type=float,
+                        default=float(24 * 60 * 60),
+                        help='clear execution interval of (seconds)'),
+                 Option('api_interval',
+                        type=float,
+                        default=1.0,
+                        help='slack api execution interval (seconds)')],
+                help=help)
+
+
+class ClearHistory(Action[ClearHistoryOption]):
+    def __init__(
+            self,
+            name: str,
+            option: ClearHistoryOption,
+            logger: Optional[logging.Logger] = None) -> None:
+        super().__init__(
+                name,
+                option,
+                logger=logger or logging.getLogger(__name__))
+
+    @staticmethod
+    def option_list(name: str) -> OptionList[ClearHistoryOption]:
+        return ClearHistoryOption.option_list(name)


### PR DESCRIPTION
ClearHistory
- 指定したchannelの指定した時間以前のmessageを削除する
- 問題点
  - 初回起動時には, team情報が取得しきれていない
  - 実行間隔や保存する期間の単位(seconds, hours)が固定されている

ThreadがCtrl+Cによって中断出来るように, `Action.stop()`を作成した