### PR TITLE
Teamをrefactoring

### DIFF
--- a/slackbot/_action.py
+++ b/slackbot/_action.py
@@ -16,6 +16,9 @@ class NoneOption(NamedTuple):
     pass
 
 
+_team = Team()
+
+
 class Action(Generic[OptionType]):
     def __init__(self,
                  name: str,
@@ -29,7 +32,7 @@ class Action(Generic[OptionType]):
         # parameter
         self._name = name
         self._option = option
-        self._team = Team()
+        self._team = _team
 
     def register(self) -> None:
         pass

--- a/slackbot/_team.py
+++ b/slackbot/_team.py
@@ -101,8 +101,8 @@ class Channel:
 class UserList:
     def __init__(
             self,
-            user_list: Optional[Iterable[User]] = None) -> None:
-        self._list = list(user_list) if user_list is not None else []
+            users: Optional[Iterable[User]] = None) -> None:
+        self._list = list(users) if users is not None else []
 
     def __iter__(self) -> Iterator[User]:
         return self._list.__iter__()
@@ -136,8 +136,8 @@ class UserList:
 class ChannelList:
     def __init__(
             self,
-            channel_list: Optional[Iterable[Channel]] = None) -> None:
-        self._list = list(channel_list) if channel_list is not None else []
+            channels: Optional[Iterable[Channel]] = None) -> None:
+        self._list = list(channels) if channels is not None else []
 
     def __iter__(self) -> Iterator[Channel]:
         return self._list.__iter__()
@@ -175,8 +175,8 @@ class Team:
     class Data:
         auth_test: Dict = {}
         team_info: Dict = {}
-        user_list = UserList()
-        channel_list = ChannelList()
+        users = UserList()
+        channels = ChannelList()
 
     _data = Data()
 
@@ -197,18 +197,18 @@ class Team:
         return self._data.team_info['domain']
 
     @property
-    def user_list(self) -> UserList:
-        return self._data.user_list
+    def users(self) -> UserList:
+        return self._data.users
 
     @property
-    def channel_list(self) -> ChannelList:
-        return self._data.channel_list
+    def channels(self) -> ChannelList:
+        return self._data.channels
 
     @property
     def bot(self) -> Optional[User]:
         bot_id = self._data.auth_test.get('user_id', None)
         if bot_id is not None:
-            return self._data.user_list.id_search(bot_id)
+            return self._data.users.id_search(bot_id)
         return None
 
     async def reset(
@@ -223,13 +223,13 @@ class Team:
         # users.list
         users_list = await client.users_list()
         if users_list.get('ok', False):
-            self._data.user_list = UserList(
+            self._data.users = UserList(
                     User(data) for data in users_list['members'])
-        # channels.list
-        channels_list = await client.conversations_list()
-        if channels_list.get('ok', False):
-            self._data.channel_list = ChannelList(
-                    Channel(data) for data in channels_list['channels'])
+        # conversations.list
+        conversations_list = await client.conversations_list()
+        if conversations_list.get('ok', False):
+            self._data.channels = ChannelList(
+                    Channel(data) for data in conversations_list['channels'])
 
     async def request_team_info(
             self,
@@ -243,7 +243,7 @@ class Team:
             self,
             client: slack.WebClient,
             channel_id: str) -> None:
-        # channels.info
+        # conversations.info
         response = await client.conversations_info(channel=channel_id)
         if response.get('ok', False):
-            self._data.channel_list.update(response['channel'])
+            self._data.channels.update(response['channel'])

--- a/slackbot/_team.py
+++ b/slackbot/_team.py
@@ -216,7 +216,7 @@ class Team:
             self,
             client: slack.WebClient,
             *,
-            limit: int = 0,
+            limit: int = 200,
             interval: float = 1.0,
             logger: Optional[logging.Logger] = None) -> None:
         # logging
@@ -242,7 +242,7 @@ class Team:
             self,
             client: slack.WebClient,
             *,
-            limit: int = 0,
+            limit: int = 200,
             interval: float = 1.0,
             logger: Optional[logging.Logger] = None) -> None:
         # logging
@@ -292,7 +292,7 @@ class Team:
             self,
             client: slack.WebClient,
             *,
-            limit: int = 0,
+            limit: int = 200,
             interval: float = 1.0,
             logger: Optional[logging.Logger] = None) -> None:
         if logger:
@@ -315,7 +315,7 @@ class Team:
             self,
             client: slack.WebClient,
             *,
-            limit: int = 0,
+            limit: int = 200,
             interval: float = 1.0,
             logger: Optional[logging.Logger] = None) -> None:
         if logger:

--- a/slackbot/_team.py
+++ b/slackbot/_team.py
@@ -172,43 +172,41 @@ class ChannelList:
 
 
 class Team:
-    class Data:
-        auth_test: Dict = {}
-        team_info: Dict = {}
-        users = UserList()
-        channels = ChannelList()
-
-    _data = Data()
+    def __init__(self) -> None:
+        self._auth_test: Dict = {}
+        self._team_info: Dict = {}
+        self._users = UserList()
+        self._channels = ChannelList()
 
     @property
     def url(self) -> str:
-        return self._data.auth_test['url']
+        return self._auth_test['url']
 
     @property
     def team_id(self) -> str:
-        return self._data.team_info['id']
+        return self._team_info['id']
 
     @property
     def team_name(self) -> str:
-        return self._data.team_info['name']
+        return self._team_info['name']
 
     @property
     def team_domain(self) -> str:
-        return self._data.team_info['domain']
+        return self._team_info['domain']
 
     @property
     def users(self) -> UserList:
-        return self._data.users
+        return self._users
 
     @property
     def channels(self) -> ChannelList:
-        return self._data.channels
+        return self._channels
 
     @property
     def bot(self) -> Optional[User]:
-        bot_id = self._data.auth_test.get('user_id', None)
+        bot_id = self._auth_test.get('user_id', None)
         if bot_id is not None:
-            return self._data.users.id_search(bot_id)
+            return self._users.id_search(bot_id)
         return None
 
     async def reset(
@@ -217,18 +215,18 @@ class Team:
         # auth.test
         auth_test = await client.auth_test()
         if auth_test.get('ok', False):
-            self._data.auth_test = auth_test
+            self._auth_test = auth_test
         # team.info
         await self.request_team_info(client)
         # users.list
         users_list = await client.users_list()
         if users_list.get('ok', False):
-            self._data.users = UserList(
+            self._users = UserList(
                     User(data) for data in users_list['members'])
         # conversations.list
         conversations_list = await client.conversations_list()
         if conversations_list.get('ok', False):
-            self._data.channels = ChannelList(
+            self._channels = ChannelList(
                     Channel(data) for data in conversations_list['channels'])
 
     async def request_team_info(
@@ -237,7 +235,7 @@ class Team:
         # team.info
         team_info = await client.team_info()
         if team_info.get('ok', False):
-            self._data.team_info = team_info['team']
+            self._team_info = team_info['team']
 
     async def request_conversations_info(
             self,
@@ -246,4 +244,4 @@ class Team:
         # conversations.info
         response = await client.conversations_info(channel=channel_id)
         if response.get('ok', False):
-            self._data.channels.update(response['channel'])
+            self._channels.update(response['channel'])

--- a/slackbot/_team.py
+++ b/slackbot/_team.py
@@ -179,6 +179,7 @@ class Team:
         self._team_info: Dict = {}
         self._users = UserList()
         self._channels = ChannelList()
+        self._is_initialized = False
 
     @property
     def url(self) -> str:
@@ -210,6 +211,32 @@ class Team:
         if bot_id is not None:
             return self._users.id_search(bot_id)
         return None
+
+    async def initialize(
+            self,
+            client: slack.WebClient,
+            *,
+            limit: int = 0,
+            interval: float = 1.0,
+            logger: Optional[logging.Logger] = None) -> None:
+        # logging
+        if logger:
+            logger.debug('begin Team.initialize()')
+            if not self._is_initialized:
+                logger.warning('Team is already initialized')
+        # reset
+        await self.reset(
+                client,
+                limit=limit,
+                interval=interval,
+                logger=logger)
+        self._is_initialized = True
+        # logging
+        if logger:
+            logger.debug('begin Team.initialize()')
+
+    def is_initialized(self) -> bool:
+        return self._is_initialized
 
     async def reset(
             self,

--- a/slackbot/_update_team.py
+++ b/slackbot/_update_team.py
@@ -100,7 +100,7 @@ class UpdateTeam(Action[UpdateTeamOption]):
     def _update_user(self, get_user: Callable[[Dict], Dict]) -> Callable:
         def callback(**payload) -> None:
             data = payload['data']
-            self.team.user_list.update(get_user(data))
+            self.team.users.update(get_user(data))
         return callback
 
     def _update_channel(self, get_id: Callable[[Dict], str]) -> Callable:
@@ -114,7 +114,7 @@ class UpdateTeam(Action[UpdateTeamOption]):
     def _delete_channel(self, get_id: Callable[[Dict], str]) -> Callable:
         def callback(**payload) -> None:
             data = payload['data']
-            self.team.channel_list.remove(get_id(data))
+            self.team.channels.remove(get_id(data))
         return callback
 
     async def _message(self, **payload) -> None:

--- a/slackbot/_update_team.py
+++ b/slackbot/_update_team.py
@@ -9,7 +9,9 @@ from ._option import Option, OptionList
 
 
 class UpdateTeamOption(NamedTuple):
+    api_interval: float
     reset_interval: float
+    limit: int
 
     @staticmethod
     def option_list(
@@ -18,10 +20,18 @@ class UpdateTeamOption(NamedTuple):
         return OptionList(
             UpdateTeamOption,
             name,
-            [Option('reset_interval',
+            [Option('api_interval',
+                    type=float,
+                    default=1.0,
+                    help='slack api execution interval (seconds)'),
+             Option('reset_interval',
                     action=lambda x: float(x) if x is not None else None,
                     default=None,
-                    help='interval seconds to reset team info')],
+                    help='interval to reset team information (seconds)'),
+             Option('limit',
+                    type=int,
+                    default=200,
+                    help='number of items per api request')],
             help=help)
 
 
@@ -84,18 +94,29 @@ class UpdateTeam(Action[UpdateTeamOption]):
                     'reset team (interval %f s)',
                     current - self._last_reset_time)
             self._last_reset_time = current
-            await self.team.reset(client)
+            await self.team.reset(
+                    client,
+                    limit=self.option.limit,
+                    interval=self.option.api_interval,
+                    logger=self._logger)
 
     async def _initialize(self, **payload) -> None:
         self._logger.debug('initialize team')
         client: Optional[slack.WebClient] = payload.get('web_client', None)
         if client is not None:
-            await self.team.initialize(client, limit=1000, logger=self._logger)
+            await self.team.initialize(
+                    client,
+                    limit=self.option.limit,
+                    interval=self.option.api_interval,
+                    logger=self._logger)
 
     async def _update_team(self, **payload) -> None:
         client: Optional[slack.WebClient] = payload.get('web_client', None)
         if client is not None:
-            await self.team.update_team(client, logger=self._logger)
+            await self.team.update_team(
+                    client,
+                    interval=self.option.api_interval,
+                    logger=self._logger)
 
     def _update_user(self, get_user: Callable[[Dict], Dict]) -> Callable:
         def callback(**payload) -> None:
@@ -111,6 +132,7 @@ class UpdateTeam(Action[UpdateTeamOption]):
                 self.team.update_channel(
                         client,
                         get_id(data),
+                        interval=self.option.api_interval,
                         logger=self._logger)
         return callback
 
@@ -130,4 +152,5 @@ class UpdateTeam(Action[UpdateTeamOption]):
             await self.team.update_channel(
                     client,
                     data['channel'],
+                    interval=self.option.api_interval,
                     logger=self._logger)

--- a/slackbot/_update_team.py
+++ b/slackbot/_update_team.py
@@ -90,7 +90,7 @@ class UpdateTeam(Action[UpdateTeamOption]):
         self._logger.debug('initialze team')
         client: Optional[slack.WebClient] = payload.get('web_client', None)
         if client is not None:
-            await self.team.reset(client)
+            await self.team.reset(client, limit=1000, logger=self._logger)
 
     async def _update_team(self, **payload) -> None:
         client: Optional[slack.WebClient] = payload.get('web_client', None)

--- a/slackbot/_update_team.py
+++ b/slackbot/_update_team.py
@@ -95,7 +95,7 @@ class UpdateTeam(Action[UpdateTeamOption]):
     async def _update_team(self, **payload) -> None:
         client: Optional[slack.WebClient] = payload.get('web_client', None)
         if client is not None:
-            await self.team.request_team_info(client)
+            await self.team.update_team(client, logger=self._logger)
 
     def _update_user(self, get_user: Callable[[Dict], Dict]) -> Callable:
         def callback(**payload) -> None:
@@ -108,7 +108,10 @@ class UpdateTeam(Action[UpdateTeamOption]):
             data = payload['data']
             client: Optional[slack.WebClient] = payload.get('web_client', None)
             if client is not None:
-                self.team.request_conversations_info(client, get_id(data))
+                self.team.update_channel(
+                        client,
+                        get_id(data),
+                        logger=self._logger)
         return callback
 
     def _delete_channel(self, get_id: Callable[[Dict], str]) -> Callable:
@@ -124,4 +127,7 @@ class UpdateTeam(Action[UpdateTeamOption]):
         if subtype in (
                 'channel_purpose', 'channel_topic',
                 'group_purpose', 'group_topic'):
-            await self.team.request_conversations_info(client, data['channel'])
+            await self.team.update_channel(
+                    client,
+                    data['channel'],
+                    logger=self._logger)

--- a/slackbot/_update_team.py
+++ b/slackbot/_update_team.py
@@ -87,10 +87,10 @@ class UpdateTeam(Action[UpdateTeamOption]):
             await self.team.reset(client)
 
     async def _initialize(self, **payload) -> None:
-        self._logger.debug('initialze team')
+        self._logger.debug('initialize team')
         client: Optional[slack.WebClient] = payload.get('web_client', None)
         if client is not None:
-            await self.team.reset(client, limit=1000, logger=self._logger)
+            await self.team.initialize(client, limit=1000, logger=self._logger)
 
     async def _update_team(self, **payload) -> None:
         client: Optional[slack.WebClient] = payload.get('web_client', None)

--- a/slackbot/action/_clear_history.py
+++ b/slackbot/action/_clear_history.py
@@ -100,7 +100,9 @@ class ClearHistory(Action[ClearHistoryOption]):
         self._is_stopped = False
 
     async def update(self, client: slack.WebClient) -> None:
-        if not self.is_in_sleep() and self._thread is None:
+        if (self.team.is_initialized()
+                and not self.is_in_sleep()
+                and self._thread is None):
             self._execution_time = _now()
             self._logger.info('execute clear at %s', self._execution_time)
             self._thread = threading.Thread(

--- a/slackbot/action/_clear_history.py
+++ b/slackbot/action/_clear_history.py
@@ -152,7 +152,7 @@ class ClearHistory(Action[ClearHistoryOption]):
                 channel_option: ChannelOption) -> List[_DeleteTarget]:
         result: List[_DeleteTarget] = []
         # channel
-        channel = self.team.channel_list.name_search(channel_option.name)
+        channel = self.team.channels.name_search(channel_option.name)
         if channel is None:
             self._logger.warning(
                     'channel \'%s\' is not found',

--- a/slackbot/action/_download.py
+++ b/slackbot/action/_download.py
@@ -94,7 +94,7 @@ class Download(Action[DownloadOption]):
 
     async def _callback(self, **payload) -> None:
         data = payload['data']
-        channel = self.team.channel_list.id_search(data['channel'])
+        channel = self.team.channels.id_search(data['channel'])
         if ('subtype' in data
                 or channel is None
                 or channel.name not in self.option.channel):

--- a/slackbot/action/_response.py
+++ b/slackbot/action/_response.py
@@ -132,14 +132,14 @@ class Response(Action[ResponseOption]):
     async def _response(self, **payload) -> None:
         data = payload['data']
         client: Optional[slack.WebClient] = payload['web_client']
-        channel = self.team.channel_list.id_search(data['channel'])
+        channel = self.team.channels.id_search(data['channel'])
         if ('subtype' in data
                 or channel is None
                 or channel.name not in self.option.channel
                 or client is None):
             return
         # user
-        user = self.team.user_list.id_search(data['user'])
+        user = self.team.users.id_search(data['user'])
         if user is None:
             return
         # message text


### PR DESCRIPTION
Team classを更新
- 変数名変更 `*_list` -> `*s`
- 各Actionでteamの値を統一する方法をclass変数から, module内の変数を用いたものに変更
- `users.list`, `conversations.list`にlimitを設定し, pagenationを使用
- 関数名変更 `request_*` -> `update_*`
- 初期化flagを追加

UpdateTeam Action
- APIの実行間隔, paginationの単位を指定するoptionを追加

ClearHistory Action
- Teamの初期化を実行条件に追加